### PR TITLE
Update obj-conv to match changes to the FileBackedMemoryShim

### DIFF
--- a/obj-conv/Cargo.toml
+++ b/obj-conv/Cargo.toml
@@ -26,9 +26,9 @@ maintenance = { status = "actively-developed" }
 
 
 [dependencies]
-lc3-isa = { git = "https://github.com/ut-utp/prototype.git", branch = "staging" }
-lc3-shims = { git = "https://github.com/ut-utp/prototype.git", branch = "staging" }
-lc3-os = { git = "https://github.com/ut-utp/prototype.git", branch = "staging" }
+lc3-isa = { git = "https://github.com/ut-utp/prototype.git", branch = "master" }
+lc3-shims = { git = "https://github.com/ut-utp/prototype.git", branch = "master" }
+lc3-os = { git = "https://github.com/ut-utp/prototype.git", branch = "master" }
 
 clap = "2.33.0"
 byteorder = "1.3.2"

--- a/obj-conv/src/main.rs
+++ b/obj-conv/src/main.rs
@@ -215,6 +215,6 @@ fn main() -> IoResult<()> {
     let _ = image.layer_loadable(program);
 
     FileBackedMemoryShim::with_initialized_memory(output_path, image)
-        .flush()
+        .flush_all_changes()
         .map_err(|_| std::io::Error::last_os_error())
 }


### PR DESCRIPTION
This is contingent on ut-utp/prototype#43 being merged. Once it is, this PR should be updated to include an updated `Cargo.lock` and merged.